### PR TITLE
fix outdated url

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An **R** library for [**GRPC**](https://grpc.io/) a high-performance, open-sourc
 ### Pre-requisites
 
 The following is copied from [gRPC C++ - Building from source](https://github.com/grpc/grpc/blob/master/BUILDING.md)
-```{bash}
+```bash
 sudo apt-get install build-essential autoconf libtool pkg-config
 ## If you plan to build from source and run tests, install the following as well:
 sudo apt-get install libgflags-dev libgtest-dev
@@ -16,7 +16,7 @@ sudo apt-get install clang libc++-dev
 
 ### Build from source
 ## Download and Install grpc
-```{bash}
+```bash
 git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc grpc_base
 cd grpc_base
 git submodule update --init

--- a/README.md
+++ b/README.md
@@ -1,4 +1,37 @@
-# grpc - An R library for RPC
+# grpc
+
+An **R** library for [**GRPC**](https://grpc.io/) a high-performance, open-source universal RPC framework.
+
+## Installation - Debian
+
+### Pre-requisites
+
+The following is copied from [gRPC C++ - Building from source](https://github.com/grpc/grpc/blob/master/BUILDING.md)
+```{bash}
+sudo apt-get install build-essential autoconf libtool pkg-config
+## If you plan to build from source and run tests, install the following as well:
+sudo apt-get install libgflags-dev libgtest-dev
+sudo apt-get install clang libc++-dev
+```
+
+### Build from source
+## Download and Install grpc
+```{bash}
+git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc grpc_base
+cd grpc_base
+git submodule update --init
+
+## In gcc 8.2 I got an error which I could fix with (see https://github.com/grpc/grpc/issues/17781)
+## with the following two export lines. (uncomment and run if you gat an error when calling make).
+#export CFLAGS='-g -O2 -w' 
+#export CXXFLAGS='-g -O2 -w'
+
+make
+sudo make install
+sudo ldconfig
+```
+
+# Original 
 
 [![Build Status](https://travis-ci.org/nfultz/grpc.svg)](https://travis-ci.org/nfultz/grpc)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An **R** library for [**GRPC**](https://grpc.io/) a high-performance, open-sourc
 ### Pre-requisites
 
 The following is copied from [gRPC C++ - Building from source](https://github.com/grpc/grpc/blob/master/BUILDING.md)
-```bash
+```shell
 sudo apt-get install build-essential autoconf libtool pkg-config
 ## If you plan to build from source and run tests, install the following as well:
 sudo apt-get install libgflags-dev libgtest-dev
@@ -16,7 +16,7 @@ sudo apt-get install clang libc++-dev
 
 ### Build from source
 ## Download and Install grpc
-```bash
+```shell
 git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc grpc_base
 cd grpc_base
 git submodule update --init

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ sudo apt-get install libgflags-dev libgtest-dev
 sudo apt-get install clang libc++-dev
 ```
 
-### Build from source
-## Download and Install grpc
+### Download and Install grpc
 ```shell
 git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc grpc_base
 cd grpc_base

--- a/install
+++ b/install
@@ -3,6 +3,10 @@ cd grpc.git/
 git checkout tags/release-0_11_1
 git submodule update --init
 cd third_party/protobuf/
+## The file 'third_party/protobuf/autogen.sh' needs to be altered since the url
+## 'https://googlemock.googlecode.com/files/gmock-1.7.0.zip' 
+## is outdated I changed to
+## wget http://pkgs.fedoraproject.org/repo/pkgs/gmock/gmock-1.7.0.zip/073b984d8798ea1594f5e44d85b20d66/gmock-1.7.0.zip
 ./autogen.sh
 ./configure
 make -j8

--- a/install
+++ b/install
@@ -1,21 +1,7 @@
-git clone https://github.com/grpc/grpc.git grpc.git
-cd grpc.git/
-git checkout tags/release-0_11_1
+git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc grpc_base
+cd grpc_base
 git submodule update --init
-cd third_party/protobuf/
-## The file 'third_party/protobuf/autogen.sh' needs to be altered since the url
-## 'https://googlemock.googlecode.com/files/gmock-1.7.0.zip' 
-## is outdated I changed to
-## wget http://pkgs.fedoraproject.org/repo/pkgs/gmock/gmock-1.7.0.zip/073b984d8798ea1594f5e44d85b20d66/gmock-1.7.0.zip
-./autogen.sh
-./configure
-make -j8
-sudo make install
-sudo ldconfig
-cd -
-make -j8
-sudo make install
-sudo ldconfig
 
-R CMD INSTALL grpc
-R -e "grpc::grpc_version()"
+make
+sudo make install
+sudo ldconfig

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,2 +1,4 @@
+CXX_STD = CXX11
 PKG_LIBS = `pkg-config --libs grpc`
 PKG_CXXFLAGS = `pkg-config --cflags grpc`
+


### PR DESCRIPTION
In the file 'third_party/protobuf/autogen.sh' the url
'https://googlemock.googlecode.com/files/gmock-1.7.0.zip' 
is outdated an easy fix this is to download gmock before executing 'autogen.sh'.