### PR TITLE
WIP Replace callWithMetadata() with call()

### DIFF
--- a/demo/helloclient.R
+++ b/demo/helloclient.R
@@ -19,7 +19,7 @@ for(who in c("Neal", "Gergely", "Jay")){
     print(as.list(message))
 
     thanks <- client$SayThanks$build(name=who)
-    message <- client$SayThanks$callWithMetadata(thanks, c("key1", "val1"))
+    message <- client$SayThanks$call(thanks, c("key1", "val1"))
     
     print(message)
     print(as.list(message))


### PR DESCRIPTION
This update Closes #33 
The function callWithMetadata() updated previously in pull request #26 with replaced with call().
It wasn't replaced in this example and this raised an error.