### PR TITLE
Update Installation Steps for grpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ export PATH="$GRPC_INSTALL_DIR/bin:$PATH"
 
 sudo apt install -y cmake
 
-git clone --recurse-submodules -b v1.35.0 https://github.com/grpc/grpc grpc_base
+LATEST_VER=$(curl -L "https://api.github.com/repos/grpc/grpc/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')
+git clone --recurse-submodules -b $LATEST_VER https://github.com/grpc/grpc grpc_base
 
 cd grpc_base
 mkdir -p cmake/build

--- a/README.md
+++ b/README.md
@@ -16,20 +16,33 @@ sudo apt-get install clang libc++-dev
 
 ### Download and Install grpc
 ```shell
-git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc grpc_base
+export GRPC_INSTALL_DIR=$HOME/.local
+mkdir -p $GRPC_INSTALL_DIR
+export PATH="$GRPC_INSTALL_DIR/bin:$PATH"
+
+sudo apt install -y cmake
+
+git clone --recurse-submodules -b v1.35.0 https://github.com/grpc/grpc grpc_base
+
 cd grpc_base
-git submodule update --init
-
-## In gcc 8.2 I got an error which I could fix with (see https://github.com/grpc/grpc/issues/17781)
-## with the following two export lines. (uncomment and run if you gat an error when calling make).
-#export CFLAGS='-g -O2 -w' 
-#export CXXFLAGS='-g -O2 -w'
-
 mkdir -p cmake/build
-cd cmake/build
-cmake ../..
-make
-sudo ldconfig
+pushd cmake/build
+cmake -DgRPC_INSTALL=ON \
+      -DgRPC_BUILD_TESTS=OFF \
+      -DCMAKE_INSTALL_PREFIX=$GRPC_INSTALL_DIR \
+      ../..
+make -j4
+sudo make install
+popd
+
+mkdir -p third_party/abseil-cpp/cmake/build
+pushd third_party/abseil-cpp/cmake/build
+cmake -DCMAKE_INSTALL_PREFIX=$GRPC_INSTALL_DIR \
+      -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
+      ../..
+make -j4
+sudo make install
+popd
 ```
 
 # Original 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ git submodule update --init
 #export CFLAGS='-g -O2 -w' 
 #export CXXFLAGS='-g -O2 -w'
 
+mkdir -p cmake/build
+cd cmake/build
+cmake ../..
 make
-sudo make install
 sudo ldconfig
 ```
 

--- a/install
+++ b/install
@@ -1,9 +1,28 @@
-git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc grpc_base
-cd grpc_base
-git submodule update --init
+export GRPC_INSTALL_DIR=$HOME/.local
+mkdir -p $GRPC_INSTALL_DIR
+export PATH="$GRPC_INSTALL_DIR/bin:$PATH"
 
+sudo apt install -y cmake
+sudo apt install -y build-essential autoconf libtool pkg-config
+
+git clone --recurse-submodules -b v1.35.0 https://github.com/grpc/grpc grpc_base
+
+cd grpc_base
 mkdir -p cmake/build
-cd cmake/build
-cmake ../..
-make
-sudo ldconfig
+pushd cmake/build
+cmake -DgRPC_INSTALL=ON \
+      -DgRPC_BUILD_TESTS=OFF \
+      -DCMAKE_INSTALL_PREFIX=$GRPC_INSTALL_DIR \
+      ../..
+make -j4
+sudo make install
+popd
+
+mkdir -p third_party/abseil-cpp/cmake/build
+pushd third_party/abseil-cpp/cmake/build
+cmake -DCMAKE_INSTALL_PREFIX=$GRPC_INSTALL_DIR \
+      -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
+      ../..
+make -j4
+sudo make install
+popd

--- a/install
+++ b/install
@@ -5,7 +5,8 @@ export PATH="$GRPC_INSTALL_DIR/bin:$PATH"
 sudo apt install -y cmake
 sudo apt install -y build-essential autoconf libtool pkg-config
 
-git clone --recurse-submodules -b v1.35.0 https://github.com/grpc/grpc grpc_base
+LATEST_VER=$(curl -L "https://api.github.com/repos/grpc/grpc/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')
+git clone --recurse-submodules -b $LATEST_VER https://github.com/grpc/grpc grpc_base
 
 cd grpc_base
 mkdir -p cmake/build

--- a/install
+++ b/install
@@ -2,6 +2,8 @@ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc grp
 cd grpc_base
 git submodule update --init
 
+mkdir -p cmake/build
+cd cmake/build
+cmake ../..
 make
-sudo make install
 sudo ldconfig


### PR DESCRIPTION
According to this [commit](https://github.com/grpc/grpc/commit/e3c1ee698d1b8f61b7b30921c3231ce7a4bc9b5f#diff-f1355fd54329147c830843ab133fed7716180c3242031487b861a2a3235d0078), building with make on UNIX systems has been deprecated. So, CMake can be used instead for building. 

The updates have been tested for successful build.