### PR TITLE
Fix compile errors in the server and client.

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,4 +1,5 @@
 CXX_STD = CXX11
 PKG_LIBS = `pkg-config --libs grpc`
+PKG_CFLAGS = `pkg-config --cflags grpc`
 PKG_CXXFLAGS = `pkg-config --cflags grpc`
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -70,10 +70,10 @@ RawVector fetch(CharacterVector server, CharacterVector method, RawVector reques
   grpc_metadata meta_c[metadata_length];
 
   for(int i = 0; i < metadata_length; i++) {
-    meta_c[i] = {grpc_slice_from_static_string(metadata[i * 2]),
-        grpc_slice_from_static_string(metadata[i * 2 + 1]),
-        0,
-        {{nullptr, nullptr, nullptr, nullptr}}};
+    meta_c[i] = grpc_metadata{
+      grpc_slice_from_static_string(metadata[i * 2]),
+      grpc_slice_from_static_string(metadata[i * 2 + 1]),
+      0, {}};
   }
 
   grpc_metadata_array initial_metadata_recv;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1,4 +1,8 @@
 #include <Rcpp.h>
+// undef the Free macro defined by Rcpp as it is redfined by absl later.
+#ifdef Free
+#undef Free
+#endif
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/byte_buffer_reader.h>
 #include "common.h"
@@ -7,7 +11,7 @@
 
 using namespace Rcpp;
 
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 using grpc::Status;
 using grpc::StatusCode;
 


### PR DESCRIPTION
The client needs to define the type of struct since instances were already allocated in the definition of the grpc_metadata array. Also, the default nullptr's can be removed from the nested obfuscated struct's creation in the same statement.

The server needs to undef the Free macro defined by Rcpp so it can be defined by absl low_level_alloc later.

These changes were tested against grpc version 1.41.1 (12a4a6f8c06b96e38f8576ded76d0b79bce13efd7560ed22134c2f433bc496ad) on Ubuntu 21.04 with gcc (Ubuntu 10.3.0-1ubuntu1) 10.3.0.

Fixes #37 